### PR TITLE
Return when topic invalid

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -58,8 +58,6 @@ exports.processUpdate = function(update, classifier, cb) {
   messagesController.createMessage(message, (m) => log.info(`Message saved: ${m.text}`));
   // Actions
   if(message.action != undefined) {
-    console.log('!!!!!!!!!!!!!!action')
-    
     if(message.action == 'edit')
       message.response = strings.$('edit', message.user.first_name);
     else if(message.action == 'confirm')
@@ -73,8 +71,6 @@ exports.processUpdate = function(update, classifier, cb) {
   
   // Topics
   else if(message.topic != undefined && message.topic != 'else') {
-    console.log('!!!!!!!!!!!!!!topic')
-    
     if(message.topic == 'update') {
       /** Deprecated **/
       // message = actions.update(message);
@@ -92,8 +88,6 @@ exports.processUpdate = function(update, classifier, cb) {
 
   // Message content
   else {
-    console.log('!!!!!!!!!!!!!!content')
-      
     if(message.text.match(/(define)/i)) {
       const word = message.text.split(/(define)/i)[2];
       actions.define(message, word, (result) => cb(result));


### PR DESCRIPTION
The processing module wasn't returning the message to the routing module if the message topic wasn't 'update' or 'flights' but not null. Added an else to the topics block to ensure message is always returned. This fixes the 499 http status that nginx was returning. Telegram was probably unhappy with this too. Sorry telegram.
